### PR TITLE
Added CI/CD pipelines for Mac/Linux/Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,64 @@
+# CI/CD pipelines for https://github.com/KarmaloopAI/karmaloop-aiml-bot-server
+
+trigger:
+  - master
+  - tags
+
+variables:
+  solution: "**/*.sln"
+  buildPlatform: "Any CPU"
+  buildConfiguration: "Release"
+
+stages:
+  - stage: build
+    jobs:
+      # Windows
+      - job: WindowsBinaries
+        pool:
+          vmImage: "windows-latest"
+        steps:
+          - task: NuGetToolInstaller@1
+
+          - task: NuGetCommand@2
+            inputs:
+              restoreSolution: "$(solution)"
+
+          - task: VSBuild@1
+            inputs:
+              solution: "$(solution)"
+              platform: "$(buildPlatform)"
+              configuration: "$(buildConfiguration)"
+          - task: CopyFiles@2
+            inputs:
+              sourceFolder: "./KarmaloopAIMLBotServer/bin/Release"
+              targetFolder: $(Build.ArtifactStagingDirectory)
+          - task: PublishBuildArtifacts@1
+            inputs:
+              pathToPublish: $(Build.ArtifactStagingDirectory)
+              artifactName: WinBinaries
+
+          # No tests !!!
+          - task: VSTest@2
+            inputs:
+              platform: "$(solution)"
+              configuration: "$(buildConfiguration)"
+
+      # Linux
+      - job: LinuxBinaries
+        pool:
+          vmImage: ubuntu-18.04
+        steps:
+          - script: sudo apt-get install mono-runtime nuget mono-xbuild
+          - script: chmod +x ./build.sh && ./build.sh
+          - publish: ./binaries
+            artifact: LinuxBinaries
+
+      # MacOS
+      - job: MacBinaries
+        pool:
+          vmImage: macOS-latest
+        steps:
+          - script: brew install autoconf automake libtool pkg-config cmake python3
+          - script: chmod +x ./build.sh && ./build.sh
+          - publish: ./binaries
+            artifact: MacBinaries


### PR DESCRIPTION
So, I noticed that fedora(32) has **removed xbuild** with the following deprecation notice
[
![Screenshot_20200714_201846](https://user-images.githubusercontent.com/44526763/87441714-0b9fff00-c611-11ea-8439-52a80262c617.png)
](url)

I confirmed that the following modification would work for all downstream distros.

```sh
dnf/apt install nuget mono mono-devel
```
And in the script file:
```diff
#Restore nuget packages
- mono nuget.exe restore
+ nuget restore
```
This PR also adds a CI/CD pipeline in azure.

**Reference** : https://dev.azure.com/suvam0451/ci-demonstration/_build/results?buildId=260&view=results